### PR TITLE
New gcoverage example, when gcov 100% line coverage does not mean all the lines from source code

### DIFF
--- a/epam/examples/gcov/hello-100/hello100.c
+++ b/epam/examples/gcov/hello-100/hello100.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+int SomeFunction (int* a) 
+{
+	return *a++;
+}
+
+/**
+* This is an example of incorrect GCOV behaviour!
+*
+* GCOV shows 100% code coverage, but in reallity we miss 
+* branch with call SomeFuction(NULL). 
+* And in this part of code is BROKEN!
+*
+*/
+int main(int argc, char *argv[])
+{
+	int value = atoi(argv[1]);
+	int result = value == 1 ? 100 : SomeFunction(NULL);
+	int a = 10;
+	SomeFunction( &a );
+	return 0;
+}

--- a/epam/examples/gcov/hello-100/makefile
+++ b/epam/examples/gcov/hello-100/makefile
@@ -1,0 +1,11 @@
+PROGRAM_NAME=hello100
+CPPFLAGS=--coverage
+#CPPFLAGS=-ftest-coverage -fprofile-arcs
+
+all:
+	gcc $(CPPFLAGS) -o $(PROGRAM_NAME) hello100.c
+
+clean:
+	rm -f $(PROGRAM_NAME) *.gcno *.gcda *.gcov *.html *.htm
+
+

--- a/epam/examples/git/cutter.sh
+++ b/epam/examples/git/cutter.sh
@@ -10,6 +10,14 @@ CNT=0
 CRAPFLAG=0
 NUM=0
 
+echo " __________________________________________________________"
+echo "|                                                          |"
+echo "|      !!! ATTENTION !!!                                   |"
+echo "|                                                          |"
+echo "|  DO NOT FORGET INITIALIZE: git config --global user.name |"
+echo "|                                                          |"
+echo " ---------------------------------------------------------" 
+
 git init
 touch $OUT
 git add $OUT

--- a/slides/profile/gcov.tex
+++ b/slides/profile/gcov.tex
@@ -147,8 +147,18 @@
       \item Обратить внимание на строку "Taken at least once 50\% of 2"
       \item Объяснить полученый результат\footnote{Дополнительная информация: \url{http://stackoverflow.com/questions/7199360/what-is-the-branch-in-the-destructor-reported-by-gcov}}
   \end{enumerate}
-
 \end{frame}
+
+\begin{frame}{Пример 5 (когда 100\% != все строки кода)}
+  \begin{enumerate}
+      \item Перейт в каталог hello100 
+      \item make 
+      \item ./hello100 1 
+      \item gcov hello100 
+      \item Обратить внимание на строку "Lines executed:100.00\%"
+  \end{enumerate}
+\end{frame}
+
 
 \begin{frame}{Пример: NFSTrace}
   \begin{center}


### PR DESCRIPTION
New gcoverage example, when gcov 100% line coverage does not mean all the lines from source code